### PR TITLE
bug(job-tracker): text overflows and html removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-hook-form": "^7.51.1",
         "sass": "^1.74.1",
         "string-format": "^2.0.0",
+        "striptags": "^3.2.0",
         "swr": "^2.2.5",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-react-aria-components": "^1.1.1"
@@ -7182,6 +7183,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/striptags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-hook-form": "^7.51.1",
     "sass": "^1.74.1",
     "string-format": "^2.0.0",
+    "striptags": "^3.2.0",
     "swr": "^2.2.5",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-react-aria-components": "^1.1.1"

--- a/src/app/api/job-reader/route.ts
+++ b/src/app/api/job-reader/route.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio'
-import { convert as convertHtml } from 'html-to-text'
+import { htmlToText } from '@/common/utils/string/htmlToText'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
         companyName: parsed?.hiringOrganization?.name,
         companyUrl: parsed?.hiringOrganization?.sameAs,
         datePosted: parsed?.datePosted,
-        jobDescription: convertHtml(parsed?.description),
+        jobDescription: htmlToText(parsed?.description),
         employmentType: parsed?.employmentType,
         jobLocationType: parsed?.jobLocationType,
         jobLocation: parsed?.jobLocation?.address?.addressCountry,
@@ -43,6 +43,8 @@ export async function POST(req: NextRequest) {
         salaryMax: parsed?.baseSalary?.value?.maxValue,
       }
     }
+
+    console.log(schema?.jobDescription)
 
     return NextResponse.json({
       schema,

--- a/src/app/api/job-reader/route.ts
+++ b/src/app/api/job-reader/route.ts
@@ -44,8 +44,6 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    console.log(schema?.jobDescription)
-
     return NextResponse.json({
       schema,
     })

--- a/src/common/ui/TextArea/TextArea.tsx
+++ b/src/common/ui/TextArea/TextArea.tsx
@@ -27,7 +27,7 @@ export const TextArea = forwardRef(function TextArea(
   }, [value])
 
   const sameStyles =
-    'text-balance text-black row-start-1 row-end-2 col-start-1 col-end-2'
+    'text-balance text-black row-start-1 row-end-2 col-start-1 col-end-2 [overflow-wrap:anywhere]'
 
   return (
     <div

--- a/src/common/utils/scraper/scraper.ts
+++ b/src/common/utils/scraper/scraper.ts
@@ -1,8 +1,0 @@
-export function scrapeJobPosting(url: string) {
-  // https://jobs.lever.co/StubHub/8e3fe08f-0aad-42dc-a2a2-df53b02cf007
-  const iframe = document.createElement('iframe')
-  iframe.onload = () => {
-    console.log('loaded')
-  }
-  //   document.appendChild(iframe);
-}

--- a/src/common/utils/string/htmlToText.ts
+++ b/src/common/utils/string/htmlToText.ts
@@ -1,0 +1,13 @@
+import striptags from 'striptags'
+import { convert as convertHtml } from 'html-to-text'
+
+export function htmlToText(html: string) {
+  striptags(
+    convertHtml(html, {
+      preserveNewlines: true,
+      selectors: [{ selector: 'p', format: 'block' }],
+    }),
+    [],
+    '\n',
+  )
+}

--- a/src/features/jobTracker/data/api/jobApplications.ts
+++ b/src/features/jobTracker/data/api/jobApplications.ts
@@ -11,7 +11,7 @@ export async function getJobsCount() {
 }
 
 export async function getJobs({
-  limit = 10,
+  limit = 100,
   offset = 0,
   orderBy = 'updatedAt',
   filter = '',
@@ -45,7 +45,6 @@ export async function createJob(data: JobModel) {
 
 export async function updateJob(id: string, data: Partial<JobModel>) {
   const supabase = await createClient()
-  console.log('update', id, data)
   return await supabase
     .from(tableName)
     .update({ ...data, id })

--- a/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
+++ b/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
@@ -68,6 +68,7 @@ export function NewJobForm({ onClose }: NewJobFormProps) {
     onClose,
   ])
 
+  console.log('jobData', jobData)
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -105,18 +106,22 @@ export function NewJobForm({ onClose }: NewJobFormProps) {
         {jobData && (
           <div className="flex gap-4 p-4 border border-solid border-grey-300 rounded-xl">
             <div className="flex-none">
-              <img
-                className="rounded-lg object-cover"
-                src={jobData['companyLogo']}
-                alt={`Logo for ${jobData['companyName']}`}
-                width="100"
-                height="100"
-              />
+              {jobData['companyLogo'] && (
+                <img
+                  className="rounded-lg object-cover"
+                  src={jobData['companyLogo']}
+                  alt={`Logo for ${jobData['companyName']}`}
+                  width="100"
+                  height="100"
+                />
+              )}
             </div>
             <div className="flex-1">
               <div>{jobData?.['jobTitle']}</div>
               <div>{jobData?.['companyName']}</div>
-              <div className="line-clamp-6">{jobData?.['jobDescription']}</div>
+              <div className="line-clamp-6 [overflow-wrap:anywhere]">
+                {jobData?.['jobDescription']}
+              </div>
             </div>
           </div>
         )}

--- a/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
+++ b/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
@@ -68,7 +68,6 @@ export function NewJobForm({ onClose }: NewJobFormProps) {
     onClose,
   ])
 
-  console.log('jobData', jobData)
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}


### PR DESCRIPTION
Fixes a few bugs in the job tracker new job scanner and TextArea.

- Fixes text wrapping issue (long URLs overflow)
- Fixes HTML striping from scanned job descriptions
- Adjusts the limit of visible jobs to 100 (for now) until we figure out hard limits, etc for how many jobs people can have at one time (before upgrading?)

Example of one of the issues:
<img width="1070" alt="Screenshot 2024-04-25 at 4 03 45 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/e2ac98ec-d0c0-4b14-8fcf-bd4cda6e1319">
