### PR TITLE
feat(job-tracker): basic archiving of jobs + button variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "string-format": "^2.0.0",
         "swr": "^2.2.5",
         "tailwind-merge": "^2.2.1",
+        "tailwind-variants": "^0.2.1",
         "tailwindcss-react-aria-components": "^1.1.1"
       },
       "devDependencies": {
@@ -7280,6 +7281,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwind-variants": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.2.1.tgz",
+      "integrity": "sha512-2xmhAf4UIc3PijOUcJPA1LP4AbxhpcHuHM2C26xM0k81r0maAO6uoUSHl3APmvHZcY5cZCY/bYuJdfFa4eGoaw==",
+      "dependencies": {
+        "tailwind-merge": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.x",
+        "pnpm": ">=7.x"
+      },
+      "peerDependencies": {
+        "tailwindcss": "*"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "string-format": "^2.0.0",
     "swr": "^2.2.5",
     "tailwind-merge": "^2.2.1",
+    "tailwind-variants": "^0.2.1",
     "tailwindcss-react-aria-components": "^1.1.1"
   },
   "devDependencies": {

--- a/src/app/(private)/candidate/job-tracker/archived/page.tsx
+++ b/src/app/(private)/candidate/job-tracker/archived/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { IconArrowLeft } from '@tabler/icons-react'
+import { JOB_TRACKER_BASEURL } from '@/features/jobTracker/data/contants/routes'
+import { ArchivedJobsList } from '@/features/jobTracker/ui/ArchivedJobsList'
+import { getJobs } from '@/features/jobTracker/data/api/jobApplications'
+
+export default async function ArchivedJobsPage() {
+  const { data, error } = await getJobs({
+    isArchived: true,
+    fields: ['jobTitle', 'companyName', 'id', 'archivedAt'],
+  })
+  console.log(data)
+  return (
+    <div className="flex flex-col gap-4 p-10">
+      <Link
+        className="flex gap-2 items-center text-sm"
+        href={JOB_TRACKER_BASEURL}
+      >
+        <IconArrowLeft size={20} /> Back to Job Tracker
+      </Link>
+      <h1 className="text-3xl font-bold">Archived Jobs</h1>
+      {data ? <ArchivedJobsList jobs={data} /> : <div>Nothing archived.</div>}
+    </div>
+  )
+}

--- a/src/app/(private)/candidate/job-tracker/archived/page.tsx
+++ b/src/app/(private)/candidate/job-tracker/archived/page.tsx
@@ -9,7 +9,11 @@ export default async function ArchivedJobsPage() {
     isArchived: true,
     fields: ['jobTitle', 'companyName', 'id', 'archivedAt'],
   })
-  console.log(data)
+
+  if (error) {
+    return <div>Sorry, an error occured.</div>
+  }
+
   return (
     <div className="flex flex-col gap-4 p-10">
       <Link

--- a/src/app/(private)/candidate/job-tracker/page.tsx
+++ b/src/app/(private)/candidate/job-tracker/page.tsx
@@ -57,7 +57,10 @@ export default async function JobTracker({
                   </div>
                 </Tab>
               </TabList>
-              <Button linkProps={{ href: `${JOB_TRACKER_BASEURL}/archived` }}>
+              <Button
+                variant="outline"
+                linkProps={{ href: `${JOB_TRACKER_BASEURL}/archived` }}
+              >
                 <IconArchive size={22} /> View Archived
               </Button>
             </div>

--- a/src/app/(private)/candidate/job-tracker/page.tsx
+++ b/src/app/(private)/candidate/job-tracker/page.tsx
@@ -1,10 +1,17 @@
-import { IconLayoutKanban, IconPlus, IconTable } from '@tabler/icons-react'
+import {
+  IconArchive,
+  IconLayoutKanban,
+  IconPlus,
+  IconTable,
+} from '@tabler/icons-react'
 import { Button } from '@/common/ui/Button'
 import { TabList, Tabs, TabPanel, Tab } from '@/common/ui/Tabs'
 import { getJobs } from '@/features/jobTracker/data/api/jobApplications'
 import { JobsTable } from '@/features/jobTracker/ui/JobsTable'
 import { JobsKanbanBoard } from '@/features/jobTracker/ui/JobsKanbanBoard'
 import { JobsFilter } from '@/features/jobTracker/ui/JobsFilter'
+import Link from 'next/link'
+import { JOB_TRACKER_BASEURL } from '@/features/jobTracker/data/contants/routes'
 
 export default async function JobTracker({
   searchParams,
@@ -35,20 +42,25 @@ export default async function JobTracker({
 
         <div className="pt-2">
           <Tabs>
-            <TabList className="px-10">
-              <Tab id="kanban">
-                <div className="flex gap-2 items-center">
-                  <IconLayoutKanban />
-                  <span>Column View</span>
-                </div>
-              </Tab>
-              <Tab id="table">
-                <div className="flex gap-2 items-center">
-                  <IconTable />
-                  <span>Table View</span>
-                </div>
-              </Tab>
-            </TabList>
+            <div className="flex items-center px-10">
+              <TabList>
+                <Tab id="kanban">
+                  <div className="flex gap-2 items-center">
+                    <IconLayoutKanban />
+                    <span>Column View</span>
+                  </div>
+                </Tab>
+                <Tab id="table">
+                  <div className="flex gap-2 items-center">
+                    <IconTable />
+                    <span>Table View</span>
+                  </div>
+                </Tab>
+              </TabList>
+              <Button linkProps={{ href: `${JOB_TRACKER_BASEURL}/archived` }}>
+                <IconArchive size={22} /> View Archived
+              </Button>
+            </div>
             <TabPanel id="table">
               <JobsTable jobs={data} />
             </TabPanel>

--- a/src/common/services/supabase/database.types.ts
+++ b/src/common/services/supabase/database.types.ts
@@ -94,6 +94,10 @@ export type Database = {
       jobApplications: {
         Row: {
           applicationStatus: Database["public"]["Enums"]["jobApplicationStatus"]
+          archivedAt: string | null
+          archivedReason:
+            | Database["public"]["Enums"]["jobApplicationArchivedReason"]
+            | null
           companyName: string
           coverLetter: string | null
           createdAt: string
@@ -102,6 +106,7 @@ export type Database = {
           jobTitle: string
           jobUrl: string | null
           notes: string | null
+          rank: string | null
           salaryMax: number | null
           salaryMin: number | null
           updatedAt: string | null
@@ -109,6 +114,10 @@ export type Database = {
         }
         Insert: {
           applicationStatus?: Database["public"]["Enums"]["jobApplicationStatus"]
+          archivedAt?: string | null
+          archivedReason?:
+            | Database["public"]["Enums"]["jobApplicationArchivedReason"]
+            | null
           companyName: string
           coverLetter?: string | null
           createdAt?: string
@@ -117,6 +126,7 @@ export type Database = {
           jobTitle: string
           jobUrl?: string | null
           notes?: string | null
+          rank?: string | null
           salaryMax?: number | null
           salaryMin?: number | null
           updatedAt?: string | null
@@ -124,6 +134,10 @@ export type Database = {
         }
         Update: {
           applicationStatus?: Database["public"]["Enums"]["jobApplicationStatus"]
+          archivedAt?: string | null
+          archivedReason?:
+            | Database["public"]["Enums"]["jobApplicationArchivedReason"]
+            | null
           companyName?: string
           coverLetter?: string | null
           createdAt?: string
@@ -132,6 +146,7 @@ export type Database = {
           jobTitle?: string
           jobUrl?: string | null
           notes?: string | null
+          rank?: string | null
           salaryMax?: number | null
           salaryMin?: number | null
           updatedAt?: string | null
@@ -214,6 +229,12 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
+      jobApplicationArchivedReason:
+        | "REJECTED"
+        | "ACCEPTED"
+        | "GHOSTED"
+        | "CLOSED"
+        | "WITHDRAWN"
       jobApplicationStatus:
         | "NOT_APPLIED"
         | "APPLIED"

--- a/src/common/ui/Button/Button.tsx
+++ b/src/common/ui/Button/Button.tsx
@@ -6,44 +6,80 @@ import {
   Button as AriaButton,
   ButtonProps as AriaButtonProps,
 } from 'react-aria-components'
+import { tv } from 'tailwind-variants'
 
 interface ButtonProps extends Omit<AriaButtonProps, 'children'> {
-  variant?: 'primary'
+  color?: 'primary' | 'secondary' | 'danger' | 'success'
+  variant?: 'outline' | 'flat'
   linkProps?: LinkProps
   children: React.ReactNode
+  className?: string
 }
 
 export function Button({
   children,
   className,
+  color,
   variant,
   linkProps,
   ...rest
 }: ButtonProps) {
-  const styles = [
-    'pointer-events-auto',
-    'rounded-full',
-    'bg-gray-200',
-    'px-5',
-    'py-3',
-    'text-sm',
-    'text-black',
-    'font-semibold',
-    'flex',
-    'gap-2',
-    'items-center',
-    'justify-center',
-    'pressed:opacity-70',
-    'hover:bg-gray-300',
-    'disabled:bg-gray-50',
-    'disabled:text-gray-500',
-  ]
-  const primaryStyles = variant === 'primary' && [
-    'text-white',
-    'bg-primary-500',
-    'hover:bg-primary-600',
-  ]
-  const finalClassName = cn(styles, primaryStyles, className)
+  const button = tv({
+    base: [
+      'pointer-events-auto',
+      'rounded-full',
+      'px-5',
+      'py-3',
+      'text-sm',
+      'font-semibold',
+      'flex',
+      'gap-2',
+      'items-center',
+      'justify-center',
+      'pressed:opacity-70',
+      'disabled:opacity-20',
+    ],
+    variants: {
+      color: {
+        success: 'bg-green-100 text-green-600 hover:bg-green-200',
+        danger: 'bg-red-100 text-red-600 hover:bg-red-200',
+        primary: 'bg-primary-100 text-primary-600 hover:bg-primary-200',
+        secondary: 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+      },
+      variant: {
+        flat: '',
+        outline: 'bg-transparent border-2 border-solid',
+      },
+    },
+    compoundVariants: [
+      {
+        color: 'danger',
+        variant: 'outline',
+        class: 'border-red-100 hover:bg-red-100',
+      },
+      {
+        color: 'primary',
+        variant: 'outline',
+        class: 'border-primary-100 hover:bg-primary-100',
+      },
+      {
+        color: 'secondary',
+        variant: 'outline',
+        class: 'border-gray-100 hover:bg-gray-100',
+      },
+      {
+        color: 'success',
+        variant: 'outline',
+        class: 'border-green-100 hover:bg-green-100',
+      },
+    ],
+    defaultVariants: {
+      variant: 'flat',
+      color: 'secondary',
+    },
+  })
+
+  const finalClassName = button({ color, variant, className })
 
   if (linkProps) {
     return (

--- a/src/common/ui/Select/index.ts
+++ b/src/common/ui/Select/index.ts
@@ -1,1 +1,1 @@
-export { Select } from './Select'
+export { Select, SelectOption } from './Select'

--- a/src/common/ui/Tabs/components/TabList.tsx
+++ b/src/common/ui/Tabs/components/TabList.tsx
@@ -10,7 +10,9 @@ export function TabList<T extends object>({
 }: TabListProps<T>) {
   return (
     <AriaTabList
-      className={cn(`flex border-b border-solid border-gray-200 ${className}`)}
+      className={cn(
+        `flex flex-1 border-b border-solid border-gray-200 ${className}`,
+      )}
       {...props}
     >
       {children}

--- a/src/features/jobTracker/data/api/jobApplications.ts
+++ b/src/features/jobTracker/data/api/jobApplications.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@/common/services/supabase/server'
-import { JobModel } from '../types'
+import { ArchivedReason, JobModel } from '../types'
 
 const tableName = 'jobApplications'
 
@@ -11,28 +11,59 @@ export async function getJobsCount() {
 }
 
 export async function getJobs({
-  limit = 10,
+  limit = 100,
   offset = 0,
   orderBy = 'updatedAt',
   filter = '',
+  isArchived = false,
+  fields = [],
 }: {
   limit?: number
   offset?: number
   orderBy?: string
   filter?: string
+  isArchived?: boolean
+  fields?: string[]
 }) {
   const supabase = await createClient()
-  return await supabase
-    .from(tableName)
-    .select()
-    .or(`companyName.ilike.%${filter}%,jobTitle.ilike.%${filter}%`)
+  // TYPE HACK: https://github.com/supabase/supabase-js/issues/551
+  const query = supabase.from(tableName).select(fields.join(',') as '*')
+  const filterBuilder = query.or(
+    `companyName.ilike.%${filter}%,jobTitle.ilike.%${filter}%`,
+  )
+  if (!isArchived) {
+    filterBuilder.is('archivedAt', null)
+  } else {
+    filterBuilder.not('archivedAt', 'is', null)
+  }
+
+  filterBuilder
     .range(offset, offset + limit)
     .order(orderBy, { ascending: false })
+
+  return await filterBuilder
 }
 
 export async function getJob(id: string) {
   const supabase = await createClient()
   return await supabase.from(tableName).select().eq('id', id)
+}
+
+export async function archiveJob(
+  id: string,
+  archivedReason: ArchivedReason = 'CLOSED',
+) {
+  return updateJob(id, {
+    archivedAt: new Date().toISOString().toLocaleString(),
+    archivedReason,
+  })
+}
+
+export async function unarchiveJob(id: string) {
+  return updateJob(id, {
+    archivedAt: null,
+    archivedReason: null,
+  })
 }
 
 export async function createJob(data: JobModel) {
@@ -45,7 +76,6 @@ export async function createJob(data: JobModel) {
 
 export async function updateJob(id: string, data: Partial<JobModel>) {
   const supabase = await createClient()
-  console.log('update', id, data)
   return await supabase
     .from(tableName)
     .update({ ...data, id })

--- a/src/features/jobTracker/data/serverActions/archiveJobApplication.ts
+++ b/src/features/jobTracker/data/serverActions/archiveJobApplication.ts
@@ -1,0 +1,14 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { archiveJob } from '../api/jobApplications'
+import { ArchivedReason } from '../types'
+import { JOB_TRACKER_BASEURL } from '../contants/routes'
+
+export async function archiveJobApplication(
+  id: string,
+  archivedReason?: ArchivedReason,
+) {
+  revalidatePath(JOB_TRACKER_BASEURL)
+  return await archiveJob(id, archivedReason)
+}

--- a/src/features/jobTracker/data/serverActions/unarchiveJobApplication.ts
+++ b/src/features/jobTracker/data/serverActions/unarchiveJobApplication.ts
@@ -1,0 +1,10 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { unarchiveJob } from '../api/jobApplications'
+import { JOB_TRACKER_BASEURL } from '../contants/routes'
+
+export async function unarchiveJobApplication(id: string) {
+  revalidatePath(JOB_TRACKER_BASEURL)
+  return await unarchiveJob(id)
+}

--- a/src/features/jobTracker/data/types.ts
+++ b/src/features/jobTracker/data/types.ts
@@ -3,6 +3,9 @@ import { Database } from '@/common/services/supabase/database.types'
 export type ApplicationStatus =
   Database['public']['Enums']['jobApplicationStatus']
 
+export type ArchivedReason =
+  Database['public']['Enums']['jobApplicationArchivedReason']
+
 // export interface JobModel {
 //   applicationStatus: ApplicationStatus
 //   jobTitle: string | null

--- a/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
+++ b/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { unarchiveJobApplication } from '../../data/serverActions/unarchiveJobApplication'
+import { JobModel } from '../../data/types'
+
+export function ArchivedJobsList({
+  jobs,
+}: {
+  jobs: Pick<JobModel, 'jobTitle' | 'companyName' | 'archivedAt' | 'id'>[]
+}) {
+  const handleUnarchivePress = (id: string) => async () => {
+    await unarchiveJobApplication(id)
+  }
+
+  return (
+    <ul>
+      {jobs?.map((job) => (
+        <li className="flex gap-2" key={job.id}>
+          <span>
+            {job.jobTitle} @ {job.companyName}
+          </span>
+          <button
+            type="button"
+            onClick={handleUnarchivePress(job.id)}
+            className="text-primary-600 underline"
+          >
+            Unarchive
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
+++ b/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
@@ -14,7 +14,7 @@ export function ArchivedJobsList({
   }
 
   return (
-    <ul>
+    <ul className="flex flex-col gap-2">
       {jobs?.map((job) => (
         <li className="flex gap-2" key={job.id}>
           <span>

--- a/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
+++ b/src/features/jobTracker/ui/ArchivedJobsList/ArchivedJobsList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { formatDistance } from 'date-fns'
 import { unarchiveJobApplication } from '../../data/serverActions/unarchiveJobApplication'
 import { JobModel } from '../../data/types'
 
@@ -17,7 +18,8 @@ export function ArchivedJobsList({
       {jobs?.map((job) => (
         <li className="flex gap-2" key={job.id}>
           <span>
-            {job.jobTitle} @ {job.companyName}
+            {job.jobTitle} @ {job.companyName} -{' '}
+            {formatDistance(Date.now(), new Date(job.archivedAt as string))}
           </span>
           <button
             type="button"

--- a/src/features/jobTracker/ui/ArchivedJobsList/index.ts
+++ b/src/features/jobTracker/ui/ArchivedJobsList/index.ts
@@ -1,0 +1,1 @@
+export { ArchivedJobsList } from './ArchivedJobsList'

--- a/src/features/jobTracker/ui/JobEditor/JobEditor.tsx
+++ b/src/features/jobTracker/ui/JobEditor/JobEditor.tsx
@@ -33,7 +33,7 @@ export function JobEditor({ jobId, isNew, values, ...rest }: CardEditorProps) {
       {...rest}
     >
       <Modal className="flex my-20 mx-auto bg-white max-w-3xl min-h-[500px] h-[calc(100vh - 100px)] drop-shadow-2xl rounded-3xl">
-        <Dialog className="p-5 flex flex-1">
+        <Dialog className="p-6 flex flex-1">
           {({ close }) => (
             <JobForm jobId={jobId} values={values} onClose={close} />
           )}

--- a/src/features/jobTracker/ui/JobEditor/JobEditor.tsx
+++ b/src/features/jobTracker/ui/JobEditor/JobEditor.tsx
@@ -26,7 +26,7 @@ export function JobEditor({ jobId, isNew, values, ...rest }: CardEditorProps) {
 
   return (
     <ModalOverlay
-      className="fixed inset-0 bg-black/50 overflow-y-auto z-200"
+      className="fixed inset-0 bg-black/60 overflow-y-auto z-200"
       isDismissable
       isOpen
       onOpenChange={handleOpenChange}

--- a/src/features/jobTracker/ui/JobForm/JobForm.tsx
+++ b/src/features/jobTracker/ui/JobForm/JobForm.tsx
@@ -2,24 +2,30 @@
 
 import { Header, Key } from 'react-aria-components'
 import { useRouter } from 'next/navigation'
-import { Tab, TabList, TabPanel, Tabs } from '@/common/ui/Tabs'
-import { IconWand, IconX } from '@tabler/icons-react'
-import { applicationStatuses } from '@/features/jobTracker/data/contants/applicationStatuses'
-import { NumberInput, TextInput } from '@/common/ui/Form'
-import { TextField } from '@/common/ui/TextField'
-import { Label } from '@/common/ui/Label'
-import { Button } from '../../../../common/ui/Button/Button'
-import { IconButton } from '../../../../common/ui/IconButton'
-import { Select } from '../../../../common/ui/Select'
-import { StatusLabel } from '../../../../common/ui/StatusLabel'
-import { TextArea } from '../../../../common/ui/TextArea'
-import { SelectOption } from '../../../../common/ui/Select/Select'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
+import {
+  IconWand,
+  IconX,
+  IconArchive,
+  IconArchiveOff,
+} from '@tabler/icons-react'
+import { NumberInput, TextInput } from '@/common/ui/Form'
+import { Label } from '@/common/ui/Label'
+import { Button } from '@/common/ui/Button'
+import { IconButton } from '@/common/ui/IconButton'
+import { Select, SelectOption } from '@/common/ui/Select'
+import { StatusLabel } from '@/common/ui/StatusLabel'
+import { Tab, TabList, TabPanel, Tabs } from '@/common/ui/Tabs'
+import { TextArea } from '@/common/ui/TextArea'
+import { TextField } from '@/common/ui/TextField'
+import { applicationStatuses } from '@/features/jobTracker/data/contants/applicationStatuses'
 import { addJobApplication } from '../../data/serverActions/addJobApplication'
 import { JobModel } from '../../data/types'
 import { updateJobApplication } from '../../data/serverActions/updateJobApplication'
 import { JOB_TRACKER_BASEURL } from '../../data/contants/routes'
 import { CompanyNameWatched, JobTitleWatched } from './components'
+import { archiveJobApplication } from '../../data/serverActions/archiveJobApplication'
+import { unarchiveJobApplication } from '../../data/serverActions/unarchiveJobApplication'
 
 interface JobFormProps {
   jobId?: string
@@ -57,6 +63,20 @@ export function JobForm({ jobId, values, onClose }: JobFormProps) {
     }
   }
 
+  const handleArchivePress = async () => {
+    // TODO: Put action behind confirm dialog
+    if (jobId) {
+      await archiveJobApplication(jobId)
+    }
+  }
+
+  const handleUnarchivePress = async () => {
+    // TODO: Put action behind confirm dialog
+    if (jobId) {
+      await unarchiveJobApplication(jobId)
+    }
+  }
+
   return (
     <form className="flex flex-col flex-1" onSubmit={handleSubmit(onSubmit)}>
       <div className="flex flex-col flex-1 gap-2">
@@ -74,11 +94,30 @@ export function JobForm({ jobId, values, onClose }: JobFormProps) {
         <div className="flex flex-1 gap-2">
           <div className="flex flex-1 flex-col gap-2">
             <Tabs>
-              <TabList aria-label="Tabs representing parts of a saved job application">
-                <Tab id="details">Job</Tab>
-                <Tab id="cover-letter">Cover Letter</Tab>
-                <Tab id="resume">Tailored Resume</Tab>
-              </TabList>
+              <div className="flex">
+                <TabList aria-label="Tabs representing parts of a saved job application">
+                  <Tab id="details">Job</Tab>
+                  <Tab id="cover-letter">Cover Letter</Tab>
+                  <Tab id="resume">Tailored Resume</Tab>
+                </TabList>
+                {values?.archivedAt !== null ? (
+                  <Button
+                    className="justify-self-end"
+                    onPress={handleUnarchivePress}
+                  >
+                    <IconArchiveOff />
+                    Unarchive
+                  </Button>
+                ) : (
+                  <Button
+                    className="justify-self-end"
+                    onPress={handleArchivePress}
+                  >
+                    <IconArchive />
+                    Archive
+                  </Button>
+                )}
+              </div>
               <TabPanel id="details">
                 <div className="flex gap-2">
                   <Controller

--- a/src/features/jobTracker/ui/JobForm/JobForm.tsx
+++ b/src/features/jobTracker/ui/JobForm/JobForm.tsx
@@ -103,6 +103,7 @@ export function JobForm({ jobId, values, onClose }: JobFormProps) {
                 {values?.archivedAt !== null ? (
                   <Button
                     className="justify-self-end"
+                    color="danger"
                     onPress={handleUnarchivePress}
                   >
                     <IconArchiveOff />
@@ -111,6 +112,7 @@ export function JobForm({ jobId, values, onClose }: JobFormProps) {
                 ) : (
                   <Button
                     className="justify-self-end"
+                    color="danger"
                     onPress={handleArchivePress}
                   >
                     <IconArchive />
@@ -249,7 +251,7 @@ export function JobForm({ jobId, values, onClose }: JobFormProps) {
 
             <Button
               className="mt-2"
-              variant="primary"
+              color="primary"
               type="submit"
               isDisabled={formState.isSubmitting}
             >

--- a/src/features/jobTracker/ui/NewJobDialog/NewJobDialog.tsx
+++ b/src/features/jobTracker/ui/NewJobDialog/NewJobDialog.tsx
@@ -19,7 +19,7 @@ export function NewJobDialog(props: ModalOverlayProps) {
 
   return (
     <ModalOverlay
-      className="fixed inset-0 bg-black/50 overflow-y-auto z-200"
+      className="fixed inset-0 bg-black/60 overflow-y-auto z-200"
       isDismissable
       isOpen
       onOpenChange={handleOpenChange}

--- a/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
+++ b/src/features/jobTracker/ui/NewJobForm/NewJobForm.tsx
@@ -65,6 +65,8 @@ export function NewJobForm({ onClose }: NewJobFormProps) {
     jobData?.companyName,
     jobData?.jobDescription,
     jobData?.jobTitle,
+    jobData?.salaryMax,
+    jobData?.salaryMin,
     onClose,
   ])
 
@@ -123,7 +125,7 @@ export function NewJobForm({ onClose }: NewJobFormProps) {
       </div>
       {jobData && (
         <div className="absolute bottom-0 right-0">
-          <Button variant="primary" onPress={onSaveJob}>
+          <Button color="primary" onPress={onSaveJob}>
             Save
           </Button>
         </div>


### PR DESCRIPTION
**View Archive link next to Job Tracker view tabs (I want to restyle tabs to pills in separate PR)**
<img width="1180" alt="Screenshot 2024-04-26 at 7 20 29 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/81eeda76-9730-45fe-961c-3159e8bf443e">

**Basic "archived jobs" page**
<img width="1181" alt="Screenshot 2024-04-26 at 7 20 36 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/f1873a00-0505-494d-b366-d299c495e790">

**Archive button on job modal**
<img width="1166" alt="Screenshot 2024-04-26 at 7 20 48 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/46a0e8d1-e0bc-4cea-916d-2fa2872db956">

**Unarchive button on job modal**
<img width="1165" alt="Screenshot 2024-04-26 at 7 21 00 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/227d1272-2c5c-4fc7-8f88-c47dc8078550">

**Button Variants: color (danger, success, primary, secondary), variant (flat, outline)**
<img width="255" alt="Screenshot 2024-04-29 at 1 00 06 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/c40a7f02-a018-4e4a-910f-023ae8892f1f">

<img width="1545" alt="Screenshot 2024-04-29 at 1 00 19 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/7fccd06c-406b-4c44-928c-fbddf94990c6">

