### PR TITLE
feat(common): make tabs rounded and fix color usage

### DIFF
--- a/src/app/(public)/_components/SubmitButton.tsx
+++ b/src/app/(public)/_components/SubmitButton.tsx
@@ -14,7 +14,7 @@ const SubmitButton = ({ children, disabled }: SubmitButtonProps) => {
       type="submit"
       aria-disabled={disabled}
       disabled={disabled}
-      className="p-2 bg-blue-500 text-white rounded-2xl hover:bg-blue-700 disabled:bg-gray-500"
+      className="p-2 bg-primary-500 text-white rounded-2xl hover:bg-primary-700 disabled:bg-gray-500"
     >
       {children}
     </button>

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -62,7 +62,7 @@ export default function LoginPage() {
           <Link
             href="/signup"
             passHref
-            className="text-blue-500 hover:text-blue-700 font-bold"
+            className="text-primary-500 hover:text-primary-700 font-bold"
           >
             Sign Up
           </Link>

--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -31,7 +31,9 @@ export default function SignupPage() {
   return (
     <div>
       <form onSubmit={onSubmit} className="w-full h-full flex flex-col">
-        <div className="w-full text-center text-3xl mb-4">Create An Account</div>
+        <div className="w-full text-center text-3xl mb-4">
+          Create An Account
+        </div>
 
         {error && (
           <div className="w-full bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4">
@@ -62,7 +64,7 @@ export default function SignupPage() {
           <Link
             href="/login"
             passHref
-            className="text-blue-500 hover:text-blue-700 font-bold"
+            className="text-primary-500 hover:text-primary-700 font-bold"
           >
             Log In
           </Link>

--- a/src/common/ui/Select/Select.tsx
+++ b/src/common/ui/Select/Select.tsx
@@ -24,7 +24,7 @@ interface SelectProps<T extends object>
 export function SelectOption({ children, ...rest }: ListBoxItemProps) {
   return (
     <ListBoxItem
-      className="p-1 rounded cursor-pointer focus:outline focus:outline-2 focus:outline-blue-500"
+      className="p-1 rounded cursor-pointer focus:outline focus:outline-2 focus:outline-primary-500"
       {...rest}
     >
       {children}
@@ -39,7 +39,7 @@ export const Select = forwardRef(function Select<T extends object>(
   return (
     <AriaSelect ref={ref} {...rest}>
       {label && <Label className="text-xs font-bold">{label}</Label>}
-      <Button className="p-1 border-solid border border-gray-300 flex gap-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-blue-500 items-center">
+      <Button className="p-1 border-solid border border-gray-300 flex gap-2 w-full rounded-lg focus:outline focus:outline-2 focus:outline-primary-500 items-center">
         <SelectValue className="flex-auto display-block" />
         <div aria-hidden="true">
           <IconChevronDown />

--- a/src/common/ui/Tabs/components/Tab.tsx
+++ b/src/common/ui/Tabs/components/Tab.tsx
@@ -7,7 +7,7 @@ export function Tab({ children, className = '', ...props }: TabProps) {
   return (
     <AriaTab
       className={cn(
-        `p-2 selected:text-blue-500 border-b-4 border-transparent border-solid selected:border-blue-500 user-select-none cursor-pointer text-sm ${className}`,
+        `px-4 py-2 self-center hover:bg-gray-200 selected:text-white selected:bg-primary-500 rounded-full user-select-none cursor-pointer text-sm ${className}`,
       )}
       {...props}
     >

--- a/src/common/ui/Tabs/components/TabList.tsx
+++ b/src/common/ui/Tabs/components/TabList.tsx
@@ -9,12 +9,7 @@ export function TabList<T extends object>({
   ...props
 }: TabListProps<T>) {
   return (
-    <AriaTabList
-      className={cn(
-        `flex flex-1 border-b border-solid border-gray-200 ${className}`,
-      )}
-      {...props}
-    >
+    <AriaTabList className={cn(`flex flex-1 gap-1 ${className}`)} {...props}>
       {children}
     </AriaTabList>
   )

--- a/src/common/ui/TextArea/TextArea.tsx
+++ b/src/common/ui/TextArea/TextArea.tsx
@@ -33,7 +33,7 @@ export const TextArea = forwardRef(function TextArea(
     <div
       className={cn(
         'grid bg-white overflow-y-none overflow-y-auto rounded-lg h-full w-full p-2 bg-white border border-solid border-gray-300',
-        isFocused && ['p-2', 'outline', 'outline-2', 'outline-blue-500'],
+        isFocused && ['p-2', 'outline', 'outline-2', 'outline-primary-500'],
       )}
     >
       <AriaTextArea

--- a/src/features/sidebar/ui/SidebarItem.tsx
+++ b/src/features/sidebar/ui/SidebarItem.tsx
@@ -40,7 +40,7 @@ export const SidebarItem = ({
           ? 'bg-sidebar-item-bg-light-selected'
           : 'hover:bg-sidebar-item-bg-light-selected hover:bg-opacity-50',
         isCurrentPath
-          ? 'text-sidebar-item-text-light-selected text-white bg-blue-500'
+          ? 'text-sidebar-item-text-light-selected text-white bg-primary-500'
           : 'text-gray-600 hover:text-sidebar-item-text-light-hover',
         'overflow-hidden',
         'flex flex-col',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,11 +21,11 @@ const config: Config = {
         'a4-document': '210 / 297',
       },
       colors: {
-        primary: colors.blue,
+        primary: colors.sky,
         'layout-divider-color': colors.gray['200'],
         // sidebar light
         'sidebar-bg-light': colors.white,
-        'sidebar-item-bg-light-selected': colors.blue,
+        'sidebar-item-bg-light-selected': colors.sky,
         'sidebar-item-text-light': colors.gray['500'],
         'sidebar-item-text-light-selected': colors.white,
         'sidebar-item-text-light-hover': colors.black,


### PR DESCRIPTION
I wanted to update the look of the tabs to match the buttons roundness. Also switched to "sky" version of blue to soften the blue tones and added "primary" color where it was just referencing "blue". Images were taken that includes the other button work, but this code is isolated to only tabs and the above mentioned blue change.

**Default tabs with selected item:**
<img width="1614" alt="Screenshot 2024-04-29 at 1 33 57 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/e281a9ba-4b35-4391-ae19-6f860e3e1ee7">
<img width="786" alt="Screenshot 2024-04-29 at 1 34 11 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/e7e256a8-1e75-40bb-9107-bcd45666ac91">
**Hover state:**
<img width="792" alt="Screenshot 2024-04-29 at 1 34 19 PM" src="https://github.com/RuffRyders/ai-job-hunter/assets/3067729/f5746594-5589-4602-9509-50ce83a07e70">
